### PR TITLE
Lights

### DIFF
--- a/crosswrd-app/package.json
+++ b/crosswrd-app/package.json
@@ -24,6 +24,7 @@
     "@types/seedrandom": "^2.4.28",
     "@types/styled-components": "^5.1.7",
     "bootstrap": "4.6",
+    "fp-ts": "^2.9.5",
     "jquery": "^3.5.1",
     "lodash": "^4.17.20",
     "popper.js": "^1.16.1",

--- a/crosswrd-app/package.json
+++ b/crosswrd-app/package.json
@@ -25,6 +25,7 @@
     "@types/styled-components": "^5.1.7",
     "bootstrap": "4.6",
     "fp-ts": "^2.9.5",
+    "immutable": "^4.0.0-rc.12",
     "jquery": "^3.5.1",
     "lodash": "^4.17.20",
     "popper.js": "^1.16.1",

--- a/crosswrd-app/src/App.tsx
+++ b/crosswrd-app/src/App.tsx
@@ -8,6 +8,8 @@ import { faGithub } from "@fortawesome/free-brands-svg-icons";
 
 import "./App.css";
 
+import { Lights } from "./Lights";
+
 type HomeProps = { name: string };
 
 const Home = ({ name }: HomeProps) => (
@@ -35,6 +37,9 @@ const Tabbed = ({ name }: HomeProps) => {
     <Tabs activeKey={key} onSelect={(k) => setKey(k ?? "/")}>
       <Tab eventKey="/" title="Home">
         <Home {...{ name }} />
+      </Tab>
+      <Tab eventKey="/lights" title="Lights">
+        <Lights />
       </Tab>
     </Tabs>
   );

--- a/crosswrd-app/src/Cell.tsx
+++ b/crosswrd-app/src/Cell.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import styled from "styled-components";
+
+export type CellProps = { light: boolean };
+
+const RawCell = styled.div<CellProps>`
+  width: 100%;
+  height: 100%;
+  min-width: 100%;
+  min-height: 100%;
+  overflow: auto;
+  background-color: ${(props) => (props.light ? "white" : "black")};
+  place-self: center center;
+  &:empty {
+    height: 30px;
+  }
+  &:hover {
+    background-color: lightsteelblue;
+    transition: all 0.1s ease 0s;
+  }
+`;
+
+export const Cell = (props: CellProps) => <RawCell {...props} />;

--- a/crosswrd-app/src/Cell.tsx
+++ b/crosswrd-app/src/Cell.tsx
@@ -10,6 +10,8 @@ export const toggleLight = (props = defaultCellProps): CellProps => ({
   light: !props.light,
 });
 
+export type CellEditProps = { toggleCell: () => void };
+
 const RawCell = styled.div<CellProps>`
   width: 100%;
   height: 100%;
@@ -27,4 +29,6 @@ const RawCell = styled.div<CellProps>`
   }
 `;
 
-export const Cell = (props: CellProps) => <RawCell {...props} />;
+export const Cell = (props: CellProps & CellEditProps) => (
+  <RawCell {...props} onClick={props.toggleCell} />
+);

--- a/crosswrd-app/src/Cell.tsx
+++ b/crosswrd-app/src/Cell.tsx
@@ -10,7 +10,7 @@ export const toggleLight = (props = defaultCellProps): CellProps => ({
   light: !props.light,
 });
 
-export type CellEditProps = { toggleCell: () => void };
+export type CellEditProps = { toggleCell: () => void; toggleOnHover: boolean };
 
 const RawCell = styled.div<CellProps>`
   width: 100%;
@@ -30,5 +30,9 @@ const RawCell = styled.div<CellProps>`
 `;
 
 export const Cell = (props: CellProps & CellEditProps) => (
-  <RawCell {...props} onClick={props.toggleCell} />
+  <RawCell
+    {...props}
+    onClick={props.toggleCell}
+    onMouseEnter={() => (props.toggleOnHover ? props.toggleCell() : {})}
+  />
 );

--- a/crosswrd-app/src/Cell.tsx
+++ b/crosswrd-app/src/Cell.tsx
@@ -3,6 +3,13 @@ import styled from "styled-components";
 
 export type CellProps = { light: boolean };
 
+const defaultCellProps: CellProps = { light: false };
+
+export const toggleLight = (props = defaultCellProps): CellProps => ({
+  ...props,
+  light: !props.light,
+});
+
 const RawCell = styled.div<CellProps>`
   width: 100%;
   height: 100%;

--- a/crosswrd-app/src/ExportLights.tsx
+++ b/crosswrd-app/src/ExportLights.tsx
@@ -2,14 +2,16 @@ import React from "react";
 import { Button, FormControl, InputGroup } from "react-bootstrap";
 
 import { CellMap } from "./Grid";
+import { StateSetter } from "./Helpers";
 import { serializeGridLights } from "./Spiral";
 
 type ExportLightsProps = {
   grid: CellMap | null;
+  setGrid: StateSetter<CellMap | null>;
   size: bigint;
 };
 
-const ExportInput = ({ grid, size }: ExportLightsProps) => (
+const ExportInput = ({ grid, setGrid, size }: ExportLightsProps) => (
   <FormControl
     type="string"
     value={grid ? serializeGridLights(size)(grid) : ""}
@@ -20,11 +22,16 @@ const ExportInput = ({ grid, size }: ExportLightsProps) => (
   />
 );
 
-export const ExportLights = (props: ExportLightsProps) => (
+export const ExportLights = ({ setGrid, ...rest }: ExportLightsProps) => (
   <InputGroup style={{ width: "fit-content", margin: "auto" }}>
     <InputGroup.Prepend>
       <InputGroup.Text>Import/Export</InputGroup.Text>
     </InputGroup.Prepend>
-    <ExportInput {...props} />
+    <ExportInput {...{ setGrid, ...rest }} />
+    <InputGroup.Append>
+      <Button variant="outline-primary" onClick={() => setGrid(null)}>
+        Reset
+      </Button>
+    </InputGroup.Append>
   </InputGroup>
 );

--- a/crosswrd-app/src/ExportLights.tsx
+++ b/crosswrd-app/src/ExportLights.tsx
@@ -3,7 +3,7 @@ import { Button, FormControl, InputGroup } from "react-bootstrap";
 
 import { CellMap } from "./Grid";
 import { StateSetter } from "./Helpers";
-import { serializeGridLights } from "./Spiral";
+import { serializeGridLights, deserializeGridLights } from "./Spiral";
 
 type ExportLightsProps = {
   grid: CellMap | null;
@@ -18,6 +18,9 @@ const ExportInput = ({ grid, setGrid, size }: ExportLightsProps) => (
     htmlSize={25}
     onClick={({ target }: React.MouseEvent) =>
       (target as HTMLInputElement).select()
+    }
+    onChange={({ target }) =>
+      setGrid(target?.value ? deserializeGridLights(target?.value) : null)
     }
   />
 );

--- a/crosswrd-app/src/ExportLights.tsx
+++ b/crosswrd-app/src/ExportLights.tsx
@@ -14,6 +14,9 @@ const ExportInput = ({ grid, size }: ExportLightsProps) => (
     type="string"
     value={grid ? serializeGridLights(size)(grid) : ""}
     htmlSize={25}
+    onClick={({ target }: React.MouseEvent) =>
+      (target as HTMLInputElement).select()
+    }
   />
 );
 

--- a/crosswrd-app/src/ExportLights.tsx
+++ b/crosswrd-app/src/ExportLights.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { Button, FormControl, InputGroup } from "react-bootstrap";
+
+import { CellMap } from "./Grid";
+import { serializeGridLights } from "./Spiral";
+
+type ExportLightsProps = {
+  grid: CellMap | null;
+  size: bigint;
+};
+
+const ExportInput = ({ grid, size }: ExportLightsProps) => (
+  <FormControl
+    type="string"
+    value={grid ? serializeGridLights(size)(grid) : ""}
+    htmlSize={25}
+  />
+);
+
+export const ExportLights = (props: ExportLightsProps) => (
+  <InputGroup style={{ width: "fit-content", margin: "auto" }}>
+    <InputGroup.Prepend>
+      <InputGroup.Text>Import/Export</InputGroup.Text>
+    </InputGroup.Prepend>
+    <ExportInput {...props} />
+  </InputGroup>
+);

--- a/crosswrd-app/src/Grid.tsx
+++ b/crosswrd-app/src/Grid.tsx
@@ -1,9 +1,21 @@
 import React from "react";
+import { flow } from "lodash";
 import { OrderedMap } from "immutable";
 import styled from "styled-components";
 
-import { CellProps } from "./Cell";
-import { Reference } from "./Reference";
+import { CellProps, toggleLight } from "./Cell";
+import { StateSetter } from "./Helpers";
+import { Reference, matchingRefs } from "./Reference";
+
+export const toggleCell = (
+  setGrid: StateSetter<CellMap | null>,
+  reference: Reference
+) => (): void =>
+  setGrid((g) =>
+    flow(
+      [...matchingRefs(reference)].map((r) => (x) => x.update(r, toggleLight))
+    )(g ?? OrderedMap())
+  );
 
 export type CellMap = OrderedMap<Reference, CellProps>;
 

--- a/crosswrd-app/src/Grid.tsx
+++ b/crosswrd-app/src/Grid.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { OrderedMap } from "immutable";
+import styled from "styled-components";
+
+import { CellProps } from "./Cell";
+import { Reference } from "./Reference";
+
+export type CellMap = OrderedMap<Reference, CellProps>;
+
+type RawGridProps = {
+  size: number;
+  cellSize: string;
+};
+
+const RawGrid = styled.div<RawGridProps>`
+  padding: 1px;
+  display: grid;
+  place-content: start center;
+  grid-template-columns: repeat(
+    ${(props) => props.size},
+    ${(props) => props.cellSize}
+  );
+  grid-template-columns: repeat(
+    ${(props) => props.size},
+    ${(props) => props.cellSize}
+  );
+  border: 1px black;
+  width: fit-content;
+  background-color: black;
+  column-gap: 1px;
+  row-gap: 1px;
+  margin: auto;
+`;
+
+export type GridProps = {
+  size: bigint;
+  children: JSX.Element[];
+};
+
+export const Grid = ({ size, children }: GridProps) => (
+  <RawGrid size={Number(size)} cellSize="30px">
+    {children}
+  </RawGrid>
+);

--- a/crosswrd-app/src/GridDisplay.tsx
+++ b/crosswrd-app/src/GridDisplay.tsx
@@ -1,7 +1,8 @@
 import { OrderedMap } from "immutable";
 
-import { CellProps } from "./Cell";
+import { Cell, CellProps } from "./Cell";
 import { CellMap } from "./Grid";
+import { StateSetter } from "./Helpers";
 import { Reference } from "./Reference";
 
 export type GridDisplay = OrderedMap<Reference, CellProps>;
@@ -23,3 +24,9 @@ export const displayGrid = (
   const g = newGrid(size);
   return grid ? g.merge(grid.filter((_, k) => g.has(k))) : g;
 };
+
+export const renderCells = (
+  setGrid: StateSetter<CellMap | null>,
+  grid: GridDisplay
+): JSX.Element[] =>
+  [...grid].map(([r, props]) => <Cell key={`${r.x},${r.y}`} {...props} />);

--- a/crosswrd-app/src/GridDisplay.tsx
+++ b/crosswrd-app/src/GridDisplay.tsx
@@ -27,12 +27,13 @@ export const displayGrid = (
 
 export const renderCells = (
   setGrid: StateSetter<CellMap | null>,
-  grid: GridDisplay
+  grid: GridDisplay,
+  toggleOnHover: boolean
 ): JSX.Element[] =>
   [...grid].map(([r, props]) => (
     <Cell
       key={`${r.x},${r.y}`}
-      {...props}
+      {...{ ...props, toggleOnHover }}
       toggleCell={toggleCell(setGrid, r)}
     />
   ));

--- a/crosswrd-app/src/GridDisplay.tsx
+++ b/crosswrd-app/src/GridDisplay.tsx
@@ -1,0 +1,25 @@
+import { OrderedMap } from "immutable";
+
+import { CellProps } from "./Cell";
+import { CellMap } from "./Grid";
+import { Reference } from "./Reference";
+
+export type GridDisplay = OrderedMap<Reference, CellProps>;
+
+export const newGrid = (size: bigint): GridDisplay =>
+  OrderedMap(
+    new Array(Number(size) ** 2).fill(null).map((_, index) => {
+      const i = BigInt(index);
+      const y = size / 2n - i / size;
+      const x = (i % size) - size / 2n;
+      return [Reference({ x, y }), { light: false }];
+    })
+  );
+
+export const displayGrid = (
+  size: bigint,
+  grid: CellMap | null
+): GridDisplay => {
+  const g = newGrid(size);
+  return grid ? g.merge(grid.filter((_, k) => g.has(k))) : g;
+};

--- a/crosswrd-app/src/GridDisplay.tsx
+++ b/crosswrd-app/src/GridDisplay.tsx
@@ -1,7 +1,7 @@
 import { OrderedMap } from "immutable";
 
 import { Cell, CellProps } from "./Cell";
-import { CellMap } from "./Grid";
+import { CellMap, toggleCell } from "./Grid";
 import { StateSetter } from "./Helpers";
 import { Reference } from "./Reference";
 
@@ -29,4 +29,10 @@ export const renderCells = (
   setGrid: StateSetter<CellMap | null>,
   grid: GridDisplay
 ): JSX.Element[] =>
-  [...grid].map(([r, props]) => <Cell key={`${r.x},${r.y}`} {...props} />);
+  [...grid].map(([r, props]) => (
+    <Cell
+      key={`${r.x},${r.y}`}
+      {...props}
+      toggleCell={toggleCell(setGrid, r)}
+    />
+  ));

--- a/crosswrd-app/src/Helpers.tsx
+++ b/crosswrd-app/src/Helpers.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+import { Button, Col, Row } from "react-bootstrap";
+
+type WrappedRowProps = { children: JSX.Element };
+export const WrappedRow = (props: WrappedRowProps) => (
+  <Row className="justify-content-center">
+    <Col md="auto">{props.children}</Col>
+  </Row>
+);

--- a/crosswrd-app/src/Helpers.tsx
+++ b/crosswrd-app/src/Helpers.tsx
@@ -1,6 +1,16 @@
 import React from "react";
 import { Button, Col, Row } from "react-bootstrap";
 
+export const popCount = (t: bigint): bigint => {
+  var b = t;
+  var c = 0n;
+  while (b > 0n) {
+    b &= b - 1n;
+    c++;
+  }
+  return c;
+};
+
 export type StateSetter<T> = React.Dispatch<React.SetStateAction<T>>;
 
 type WrappedRowProps = { children: JSX.Element };

--- a/crosswrd-app/src/Helpers.tsx
+++ b/crosswrd-app/src/Helpers.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import { Button, Col, Row } from "react-bootstrap";
 
+export type StateSetter<T> = React.Dispatch<React.SetStateAction<T>>;
+
 type WrappedRowProps = { children: JSX.Element };
 export const WrappedRow = (props: WrappedRowProps) => (
   <Row className="justify-content-center">

--- a/crosswrd-app/src/Helpers.tsx
+++ b/crosswrd-app/src/Helpers.tsx
@@ -9,3 +9,15 @@ export const WrappedRow = (props: WrappedRowProps) => (
     <Col md="auto">{props.children}</Col>
   </Row>
 );
+
+type ToggleButtonProps = {
+  children: JSX.Element | string;
+  value: boolean;
+  toggle: () => void;
+};
+
+export const ToggleButton = (props: ToggleButtonProps) => (
+  <Button variant="outline-primary" onClick={props.toggle} active={props.value}>
+    {props.children}
+  </Button>
+);

--- a/crosswrd-app/src/Lights.tsx
+++ b/crosswrd-app/src/Lights.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { Container } from "react-bootstrap";
 
-import { CellMap, Grid } from "./Grid";
+import { Grid, CellMap } from "./Grid";
 import { displayGrid, renderCells } from "./GridDisplay";
 import { WrappedRow, StateSetter } from "./Helpers";
 

--- a/crosswrd-app/src/Lights.tsx
+++ b/crosswrd-app/src/Lights.tsx
@@ -1,15 +1,15 @@
 import React from "react";
-import { Col, Container, Row } from "react-bootstrap";
+import { Container } from "react-bootstrap";
+
+import { WrappedRow } from "./Helpers";
 
 const Lights = () => (
   <Container>
-    <Row>
-      <Col>
-        <header>
-          <h1>Edit lights</h1>
-        </header>
-      </Col>
-    </Row>
+    <WrappedRow>
+      <header>
+        <h1>Edit lights</h1>
+      </header>
+    </WrappedRow>
   </Container>
 );
 

--- a/crosswrd-app/src/Lights.tsx
+++ b/crosswrd-app/src/Lights.tsx
@@ -3,14 +3,22 @@ import { Container } from "react-bootstrap";
 
 import { Grid, CellMap } from "./Grid";
 import { displayGrid, renderCells } from "./GridDisplay";
-import { WrappedRow, StateSetter } from "./Helpers";
+import { WrappedRow, StateSetter, ToggleButton } from "./Helpers";
 
 type LightsLayoutProps = {
   size: bigint;
   grid: CellMap | null;
   setGrid: StateSetter<CellMap | null>;
+  toggleOnHover: boolean;
+  toggleToggleOnHover: () => void;
 };
-const LightsLayout = ({ size, grid, setGrid }: LightsLayoutProps) => (
+const LightsLayout = ({
+  size,
+  grid,
+  setGrid,
+  toggleOnHover,
+  toggleToggleOnHover,
+}: LightsLayoutProps) => (
   <Container>
     <WrappedRow>
       <header>
@@ -18,7 +26,14 @@ const LightsLayout = ({ size, grid, setGrid }: LightsLayoutProps) => (
       </header>
     </WrappedRow>
     <WrappedRow>
-      <Grid {...{ size }}>{renderCells(setGrid, displayGrid(size, grid))}</Grid>
+      <Grid {...{ size }}>
+        {renderCells(setGrid, displayGrid(size, grid), toggleOnHover)}
+      </Grid>
+    </WrappedRow>
+    <WrappedRow>
+      <ToggleButton value={toggleOnHover} toggle={toggleToggleOnHover}>
+        Toggle on hover
+      </ToggleButton>
     </WrappedRow>
   </Container>
 );
@@ -27,7 +42,14 @@ const Lights = () => {
   const size = 15n;
   const [grid, setGrid] = useState<CellMap | null>(null);
 
-  return <LightsLayout {...{ size, grid, setGrid }} />;
+  const [toggleOnHover, setToggleOnHover] = useState<boolean>(false);
+  const toggleToggleOnHover = () => setToggleOnHover((x) => !x);
+
+  return (
+    <LightsLayout
+      {...{ size, grid, setGrid, toggleOnHover, toggleToggleOnHover }}
+    />
+  );
 };
 
 export { Lights };

--- a/crosswrd-app/src/Lights.tsx
+++ b/crosswrd-app/src/Lights.tsx
@@ -1,20 +1,33 @@
-import React from "react";
+import React, { useState } from "react";
 import { Container } from "react-bootstrap";
 
-import { WrappedRow } from "./Helpers";
+import { CellMap, Grid } from "./Grid";
+import { displayGrid, renderCells } from "./GridDisplay";
+import { WrappedRow, StateSetter } from "./Helpers";
 
-const LightsLayout = () => (
+type LightsLayoutProps = {
+  size: bigint;
+  grid: CellMap | null;
+  setGrid: StateSetter<CellMap | null>;
+};
+const LightsLayout = ({ size, grid, setGrid }: LightsLayoutProps) => (
   <Container>
     <WrappedRow>
       <header>
         <h1>Edit lights</h1>
       </header>
     </WrappedRow>
+    <WrappedRow>
+      <Grid {...{ size }}>{renderCells(setGrid, displayGrid(size, grid))}</Grid>
+    </WrappedRow>
   </Container>
 );
 
 const Lights = () => {
-  return <LightsLayout />;
+  const size = 15n;
+  const [grid, setGrid] = useState<CellMap | null>(null);
+
+  return <LightsLayout {...{ size, grid, setGrid }} />;
 };
 
 export { Lights };

--- a/crosswrd-app/src/Lights.tsx
+++ b/crosswrd-app/src/Lights.tsx
@@ -4,6 +4,7 @@ import { Container } from "react-bootstrap";
 import { Grid, CellMap } from "./Grid";
 import { displayGrid, renderCells } from "./GridDisplay";
 import { WrappedRow, StateSetter, ToggleButton } from "./Helpers";
+import { ExportLights } from "./ExportLights";
 
 type LightsLayoutProps = {
   size: bigint;
@@ -34,6 +35,9 @@ const LightsLayout = ({
       <ToggleButton value={toggleOnHover} toggle={toggleToggleOnHover}>
         Toggle on hover
       </ToggleButton>
+    </WrappedRow>
+    <WrappedRow>
+      <ExportLights {...{ grid, size }} />
     </WrappedRow>
   </Container>
 );

--- a/crosswrd-app/src/Lights.tsx
+++ b/crosswrd-app/src/Lights.tsx
@@ -37,7 +37,7 @@ const LightsLayout = ({
       </ToggleButton>
     </WrappedRow>
     <WrappedRow>
-      <ExportLights {...{ grid, size }} />
+      <ExportLights {...{ grid, setGrid, size }} />
     </WrappedRow>
   </Container>
 );

--- a/crosswrd-app/src/Lights.tsx
+++ b/crosswrd-app/src/Lights.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import { Col, Container, Row } from "react-bootstrap";
+
+const Lights = () => (
+  <Container>
+    <Row>
+      <Col>
+        <header>
+          <h1>Edit lights</h1>
+        </header>
+      </Col>
+    </Row>
+  </Container>
+);
+
+export { Lights };

--- a/crosswrd-app/src/Lights.tsx
+++ b/crosswrd-app/src/Lights.tsx
@@ -3,7 +3,7 @@ import { Container } from "react-bootstrap";
 
 import { WrappedRow } from "./Helpers";
 
-const Lights = () => (
+const LightsLayout = () => (
   <Container>
     <WrappedRow>
       <header>
@@ -12,5 +12,9 @@ const Lights = () => (
     </WrappedRow>
   </Container>
 );
+
+const Lights = () => {
+  return <LightsLayout />;
+};
 
 export { Lights };

--- a/crosswrd-app/src/Reference.tsx
+++ b/crosswrd-app/src/Reference.tsx
@@ -1,0 +1,8 @@
+import { Record } from "immutable";
+
+export const Reference = Record<{ x: bigint; y: bigint }>(
+  { x: 0n, y: 0n },
+  "Reference" as string
+);
+const centre = Reference();
+export type Reference = typeof centre;

--- a/crosswrd-app/src/Reference.tsx
+++ b/crosswrd-app/src/Reference.tsx
@@ -1,4 +1,4 @@
-import { Record } from "immutable";
+import { Record, Set } from "immutable";
 
 export const Reference = Record<{ x: bigint; y: bigint }>(
   { x: 0n, y: 0n },
@@ -6,3 +6,9 @@ export const Reference = Record<{ x: bigint; y: bigint }>(
 );
 const centre = Reference();
 export type Reference = typeof centre;
+
+export const rotate180 = (r: Reference): Reference =>
+  Reference({ x: -r.x, y: -r.y });
+
+export const matchingRefs = (r: Reference): Set<Reference> =>
+  Set([r, rotate180(r)]);

--- a/crosswrd-app/src/Spiral.tsx
+++ b/crosswrd-app/src/Spiral.tsx
@@ -1,3 +1,6 @@
+import { flow } from "lodash";
+
+import { CellMap } from "./Grid";
 import { Reference } from "./Reference";
 
 function* spiralSpans() {
@@ -42,3 +45,17 @@ function* spiralIndices(end: bigint) {
 }
 
 type GridLights = boolean[];
+
+export const serializeGridLights = (size: bigint): ((_: CellMap) => string) =>
+  flow([gridLightsFromCellMap(size), stringFromGridLights]);
+
+const stringFromGridLights = (gs: GridLights): string =>
+  chunk(gs, 8)
+    .reverse()
+    .map((c) => c.reduceRight((acc, l) => (acc << 1) | +l, 0).toString(16))
+    .join("");
+
+const gridLightsFromCellMap = (size: bigint) => (grid: CellMap): GridLights => {
+  const indices = spiralIndices(size);
+  return [...indices].map((r) => grid.get(r)?.light ?? false);
+};

--- a/crosswrd-app/src/Spiral.tsx
+++ b/crosswrd-app/src/Spiral.tsx
@@ -87,10 +87,10 @@ const gridFromChunks = (chunks: boolean[][]): CellMap =>
   OrderedMap(
     chunks.flatMap((c, index): [Reference, CellProps][] => {
       const r = BigInt(index);
-      const xExp = BigInt(!(popCount(r & 3n) & 1n));
-      const yExp = BigInt(!(r & 2n));
-      const x = ((-1n) ** xExp * (r + 1n)) / 2n; // start
-      const y = ((-1n) ** yExp * r) / 2n; // end
+      const xExp = Number(!(popCount(r & 3n) & 1n));
+      const yExp = Number(!(r & 2n));
+      const x = (BigInt((-1) ** xExp) * (r + 1n)) / 2n; // start
+      const y = (BigInt((-1) ** yExp) * r) / 2n; // end
       const pos = (ind: number): Reference => {
         const i = BigInt(ind);
         switch (r % 4n) {

--- a/crosswrd-app/src/Spiral.tsx
+++ b/crosswrd-app/src/Spiral.tsx
@@ -1,4 +1,4 @@
-import { flow } from "lodash";
+import { chunk, flow } from "lodash";
 
 import { CellMap } from "./Grid";
 import { Reference } from "./Reference";

--- a/crosswrd-app/src/Spiral.tsx
+++ b/crosswrd-app/src/Spiral.tsx
@@ -1,0 +1,42 @@
+import { Reference } from "./Reference";
+
+function* spiralSpans() {
+  var index = 0n;
+  while (true) {
+    yield 1n + 2n * (index++ / 2n);
+  }
+}
+
+function* spiralIndices(end: bigint) {
+  var index = 0n;
+  var r = 0n;
+  const chunks = spiralSpans();
+  var c = (chunks.next().value || 1n) - 1n;
+  var reference = Reference();
+  while (c < (end ?? Infinity)) {
+    yield reference;
+    const { x, y } = reference;
+    switch (r % 4n) {
+      case 0n:
+        reference = Reference({ x: x + 1n, y });
+        break;
+      case 1n:
+        reference = Reference({ x, y: y + 1n });
+        break;
+      case 2n:
+        reference = Reference({ x: x - 1n, y });
+        break;
+      default:
+        reference = Reference({ x, y: y - 1n });
+        break;
+    }
+    if (c) {
+      c--;
+    } else {
+      r++;
+      c = (chunks.next().value || 1n) - 1n;
+    }
+    index++;
+  }
+  return index;
+}

--- a/crosswrd-app/src/Spiral.tsx
+++ b/crosswrd-app/src/Spiral.tsx
@@ -40,3 +40,5 @@ function* spiralIndices(end: bigint) {
   }
   return index;
 }
+
+type GridLights = boolean[];

--- a/crosswrd-app/tsconfig.json
+++ b/crosswrd-app/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es6",
+    "target": "es2020",
     "lib": [
       "dom",
       "dom.iterable",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,8 @@ importers:
       '@types/seedrandom': 2.4.28
       '@types/styled-components': 5.1.7
       bootstrap: 4.6.0_jquery@3.5.1+popper.js@1.16.1
+      fp-ts: 2.9.5
+      immutable: 4.0.0-rc.12
       jquery: 3.5.1
       lodash: 4.17.20
       popper.js: 1.16.1
@@ -56,6 +58,8 @@ importers:
       '@types/seedrandom': ^2.4.28
       '@types/styled-components': ^5.1.7
       bootstrap: '4.6'
+      fp-ts: ^2.9.5
+      immutable: ^4.0.0-rc.12
       jquery: ^3.5.1
       lodash: ^4.17.20
       popper.js: ^1.16.1
@@ -5752,6 +5756,10 @@ packages:
       node: '>= 0.6'
     resolution:
       integrity: sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=
+  /fp-ts/2.9.5:
+    dev: false
+    resolution:
+      integrity: sha512-MiHrA5teO6t8zKArE3DdMPT/Db6v2GUt5yfWnhBTrrsVfeCJUUnV6sgFvjGNBKDmEMqVwRFkEePL7wPwqrLKKA==
   /fragment-cache/0.2.1:
     dependencies:
       map-cache: 0.2.2
@@ -6393,6 +6401,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-Vs/gxoM4DqNAYR7pugIxi0Xc8XAun/uy7AQu4fLLqaTBHxjOP9pJ266Q9MWA/ly4z6rAFZbvViOtihxUZ7O28A==
+  /immutable/4.0.0-rc.12:
+    dev: false
+    resolution:
+      integrity: sha512-0M2XxkZLx/mi3t8NVwIm1g8nHoEmM9p9UBl/G9k4+hm0kBgOVdMV/B3CY5dQ8qG8qc80NN4gDV4HQv6FTJ5q7A==
   /import-cwd/2.1.0:
     dependencies:
       import-from: 2.1.0


### PR DESCRIPTION
Edit grids. Import/export. No numbers, yet.

- [x] Fix bigint conversion (an es2020 issue?) microsoft/TypeScript#30398 I don't get why it only shows up in builds/prod. Maybe because builds use babel?