### PR TITLE
Only number grid based on visible lights

### DIFF
--- a/crosswrd-app/src/common/ClueStarts.tsx
+++ b/crosswrd-app/src/common/ClueStarts.tsx
@@ -40,9 +40,13 @@ const clueStart = (neighbours: (_: Reference) => (boolean | null)[]) => (
   return [i + 1n, cs.set(r, { clueNumber: i, directions })];
 };
 
-export const findClueStarts = (lights: Lights): ClueStarts => {
-  const neighbours = neighbourhood(lights);
-  return lights.reduce(clueStart(neighbours), [
+const inGrid = (size: bigint) => (_: unknown, r: Reference): boolean =>
+  [r.x, r.y].every((z) => Math.abs(Number(z)) <= size / 2n);
+
+export const findClueStarts = (lights: Lights, size: bigint): ClueStarts => {
+  const grid = lights.filter(inGrid(size));
+  const neighbours = neighbourhood(grid);
+  return grid.reduce(clueStart(neighbours), [
     1n,
     OrderedMap() as ClueStarts,
   ])[1];

--- a/crosswrd-app/src/components/EditLights.tsx
+++ b/crosswrd-app/src/components/EditLights.tsx
@@ -54,7 +54,9 @@ const EditLights = () => {
   const [lights, setLights] = useState<Lights | null>(null);
   const [clueStarts, setClueStarts] = useState<ClueStarts | null>(null);
 
-  useEffect(() => setClueStarts(lights && findClueStarts(lights)), [lights]);
+  useEffect(() => {
+    setClueStarts(lights && findClueStarts(lights, size));
+  }, [lights, size]);
 
   const [toggleOnHover, setToggleOnHover] = useState<boolean>(false);
   const toggleToggleOnHover = () => setToggleOnHover((x) => !x);


### PR DESCRIPTION
Without this, we were including lights from imports in the numbering algorithm. We filter the lights by index to ensure they stay within the size.

Note: Wrapping the single expression in the `useEffects` callback is for `prettier` as it prevents the dependency list breaking over multiple lines.

Fixes #14 

---

![Filtering the lights means the numbering now works correctly](https://user-images.githubusercontent.com/870937/108611724-24f3ff80-73d9-11eb-8606-43344c80d368.png)
