### PR TITLE
Add Sentry with error boundaries

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,3 +59,12 @@ jobs:
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+
+      - name: Create a Sentry release
+        uses: getsentry/action-release@v1
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+        with:
+          environment: production

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,6 +42,10 @@ jobs:
               args: [--frozen-lockfile]
 
       - name: Build 🔧
+        env:
+          REACT_APP_SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          REACT_APP_DEPLOY_SHA: ${{ env.GITHUB_SHA }}
+          REACT_APP_CONTEXT: production
         run: |
           pnpm -C crosswrd-app run build
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,10 @@ jobs:
               args: [--frozen-lockfile]
 
       - name: Build 🔧
+        env:
+          REACT_APP_SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+          REACT_APP_DEPLOY_SHA: ${{ github.event.pull_request.head.sha }}
+          REACT_APP_CONTEXT: deploy-preview
         run: |
           pnpm -C crosswrd-app run build
 

--- a/crosswrd-app/package.json
+++ b/crosswrd-app/package.json
@@ -8,6 +8,7 @@
     "@fortawesome/free-brands-svg-icons": "^5.15.2",
     "@fortawesome/free-solid-svg-icons": "^5.15.2",
     "@fortawesome/react-fontawesome": "^0.1.14",
+    "@sentry/react": "^6.2.1",
     "@testing-library/dom": "^7.21.4",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",

--- a/crosswrd-app/src/components/Helpers.tsx
+++ b/crosswrd-app/src/components/Helpers.tsx
@@ -1,12 +1,15 @@
 import { Dispatch, SetStateAction } from "react";
 import { Button, Col, Row } from "react-bootstrap";
+import { ErrorBoundary } from "@sentry/react";
 
 export type StateSetter<T> = Dispatch<SetStateAction<T>>;
 
 type WrappedRowProps = { children: JSX.Element };
 export const WrappedRow = (props: WrappedRowProps) => (
   <Row className="justify-content-center">
-    <Col md="auto">{props.children}</Col>
+    <Col md="auto">
+      <ErrorBoundary fallback={null}>{props.children}</ErrorBoundary>
+    </Col>
   </Row>
 );
 

--- a/crosswrd-app/src/index.tsx
+++ b/crosswrd-app/src/index.tsx
@@ -7,7 +7,11 @@ import "bootstrap/dist/css/bootstrap.min.css";
 import App from "./components/App";
 import reportWebVitals from "./reportWebVitals";
 
-Sentry({ dsn: process.env.REACT_APP_SENTRY_DSN });
+Sentry({
+  dsn: process.env.REACT_APP_SENTRY_DSN,
+  release: `crosswrd@${process.env.REACT_APP_DEPLOY_SHA}`,
+  environment: process.env.REACT_APP_CONTEXT,
+});
 
 render(
   <StrictMode>

--- a/crosswrd-app/src/index.tsx
+++ b/crosswrd-app/src/index.tsx
@@ -1,9 +1,13 @@
 import { StrictMode } from "react";
 import { render } from "react-dom";
+import { init as Sentry } from "@sentry/react";
+
 import "./index.css";
 import "bootstrap/dist/css/bootstrap.min.css";
 import App from "./components/App";
 import reportWebVitals from "./reportWebVitals";
+
+Sentry({ dsn: process.env.REACT_APP_SENTRY_DSN });
 
 render(
   <StrictMode>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ importers:
       '@fortawesome/free-brands-svg-icons': 5.15.2
       '@fortawesome/free-solid-svg-icons': 5.15.2
       '@fortawesome/react-fontawesome': 0.1.14_fdbbf59a1e8653ce678e6d59b8f3bef7
+      '@sentry/react': 6.2.1_react@17.0.1
       '@testing-library/dom': 7.29.4
       '@testing-library/jest-dom': 5.11.9
       '@testing-library/react': 11.2.5_react-dom@17.0.1+react@17.0.1
@@ -42,6 +43,7 @@ importers:
       '@fortawesome/free-brands-svg-icons': ^5.15.2
       '@fortawesome/free-solid-svg-icons': ^5.15.2
       '@fortawesome/react-fontawesome': ^0.1.14
+      '@sentry/react': ^6.2.1
       '@testing-library/dom': ^7.21.4
       '@testing-library/jest-dom': ^5.11.4
       '@testing-library/react': ^11.1.0
@@ -1810,6 +1812,80 @@ packages:
       rollup: ^1.20.0||^2.0.0
     resolution:
       integrity: sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==
+  /@sentry/browser/6.2.1:
+    dependencies:
+      '@sentry/core': 6.2.1
+      '@sentry/types': 6.2.1
+      '@sentry/utils': 6.2.1
+      tslib: 1.14.1
+    dev: false
+    engines:
+      node: '>=6'
+    resolution:
+      integrity: sha512-OAikFZ9EimD3noxMp8tA6Cf6qJcQ2U8k5QSgTPwdx+09nZOGJzbRFteK7WWmrS93ZJdzN61lpSQbg5v+bmmfbQ==
+  /@sentry/core/6.2.1:
+    dependencies:
+      '@sentry/hub': 6.2.1
+      '@sentry/minimal': 6.2.1
+      '@sentry/types': 6.2.1
+      '@sentry/utils': 6.2.1
+      tslib: 1.14.1
+    dev: false
+    engines:
+      node: '>=6'
+    resolution:
+      integrity: sha512-jPqQEtafxxDtLONhCbTHh/Uq8mZRhsfbwJTSVYfPVEe/ELfFZLQK7tP6rOh7zEWKbTkE0mE6XcaoH3ZRAhgrqg==
+  /@sentry/hub/6.2.1:
+    dependencies:
+      '@sentry/types': 6.2.1
+      '@sentry/utils': 6.2.1
+      tslib: 1.14.1
+    dev: false
+    engines:
+      node: '>=6'
+    resolution:
+      integrity: sha512-pG7wCQeRpzeP6t0bT4T0X029R19dbDS3/qswF8BL6bg0AI3afjfjBAZm/fqn1Uwe/uBoMHVVdbxgJDZeQ5d4rQ==
+  /@sentry/minimal/6.2.1:
+    dependencies:
+      '@sentry/hub': 6.2.1
+      '@sentry/types': 6.2.1
+      tslib: 1.14.1
+    dev: false
+    engines:
+      node: '>=6'
+    resolution:
+      integrity: sha512-wuSXB4Ayxv9rBEQ4pm7fnG4UU2ZPtPnnChoEfd4/mw1UthXSvmPFEn6O4pdo2G8fTkl8eqm6wT/Q7uIXMEmw+A==
+  /@sentry/react/6.2.1_react@17.0.1:
+    dependencies:
+      '@sentry/browser': 6.2.1
+      '@sentry/minimal': 6.2.1
+      '@sentry/types': 6.2.1
+      '@sentry/utils': 6.2.1
+      hoist-non-react-statics: 3.3.2
+      react: 17.0.1
+      tslib: 1.14.1
+    dev: false
+    engines:
+      node: '>=6'
+    peerDependencies:
+      react: 15.x || 16.x || 17.x
+    resolution:
+      integrity: sha512-emJnYVASM2hej2f8eSjqiDRMljwLsDJDSwa6kVc5HUOs9gnVrE4MR+vSywraACf5tKZbH1YI+NUXCmR++fIB0g==
+  /@sentry/types/6.2.1:
+    dev: false
+    engines:
+      node: '>=6'
+    resolution:
+      integrity: sha512-h0OV1QT+fv5ojfK5/+iEXClu33HirmvbjcQC2jf05IHj9yXIOWy6EB10S8nBjuLiiFqQiAQYj3FN9Ip4eN8NJA==
+  /@sentry/utils/6.2.1:
+    dependencies:
+      '@sentry/types': 6.2.1
+      tslib: 1.14.1
+    dev: false
+    engines:
+      node: '>=6'
+    resolution:
+      integrity: sha512-6kQgM/yBPdXu+3qbJnI6HBcWztN9QfiMkH++ZiKk4ERhg9d2LYWlze478uTU5Fyo/JQYcp+McpjtjpR9QIrr0g==
   /@sinonjs/commons/1.8.2:
     dependencies:
       type-detect: 4.0.8


### PR DESCRIPTION
I get an insane sentry allowance thanks to github education pack — I should note when this runs out (next February?).

Should help with #27