### PR TITLE
Attempt to fix indexing undefined on iOS

### DIFF
--- a/crosswrd-app/src/common/Reference.tsx
+++ b/crosswrd-app/src/common/Reference.tsx
@@ -7,8 +7,8 @@ export const Reference = Record<{ x: bigint; y: bigint }>(
 const centre = Reference();
 export type Reference = typeof centre;
 
-export const rotate180 = (r: Reference): Reference =>
-  Reference({ x: -r.x, y: -r.y });
+export const rotate180 = ({ x, y }: Reference): Reference =>
+  Reference({ x: -x, y: -y });
 
 export const matchingRefs = (r: Reference): Set<Reference> =>
   Set([r, rotate180(r)]);


### PR DESCRIPTION
This is a really stupid fix that shouldn’t work and probably won’t. It’s worth a shot, though.

Attempts to fix CROSSWRD-6
Attempts to fix #27